### PR TITLE
Change bounds of StereoPannerNode 'pan' to ± 1.0

### DIFF
--- a/popup.js
+++ b/popup.js
@@ -16,7 +16,7 @@ function currenttabcallback(callback)
 function setvalue()
 {
 	var newval = document.getElementById('AudioPanExtensionPanInput').value;
-	newval = (newval / 5);
+	newval = (newval / 4);
 	
 	currenttabcallback(function(tabid)
 	{


### PR DESCRIPTION
The min and max values for the pan of a StereoPannerNode [are -1 and 1](https://developer.mozilla.org/en-US/docs/Web/API/StereoPannerNode) respectively. The input in `popup.html` returns a value from -4 to 4, which was then divided by 5 in `popup.js` to create a normalized value passed to the AudioContext created in `background.js`. This gives the pan an effective range of ± 0.8, rather than the actual min-max values.

When a user wants audio from a tab to be output in only one channel, only an 80% pan can then be obtained. Changing the denominator to 4 in `popup.js` allows for a complete pan (min-max of ± 1.0 instead of ± 0.8).